### PR TITLE
mprove Electron UX and dashboard transaction details

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,7 +35,6 @@
     ],
     "win": {
       "icon": "../backend/finance/static/favicon.ico",
-      "signAndEditExecutable": false,
       "target": [
         "nsis",
         "portable"
@@ -43,7 +42,9 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "installerIcon": "../backend/finance/static/favicon.ico",
+      "uninstallerIcon": "../backend/finance/static/favicon.ico"
     }
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 import { Component, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { apiGet, apiPatch } from "./api.js";
-import { Spinner } from "./components.jsx";
+import { ConfirmDialog, Spinner } from "./components.jsx";
 import DashboardPage from "./pages/DashboardPage.jsx";
 import {
   accentPresets,
@@ -53,6 +53,7 @@ export default function App() {
   const [loadingDashboard, setLoadingDashboard] = useState(false);
   const [importReport, setImportReport] = useState(null);
   const [maintenanceSummary, setMaintenanceSummary] = useState(null);
+  const [confirmation, setConfirmation] = useState(null);
   const [mappingDraft, setMappingDraft] = useState({
     column_map: {},
     categorization_fields: defaultCategorizationFields,
@@ -60,11 +61,40 @@ export default function App() {
     detected: null,
   });
   const filterSelectionsInitialized = useRef(false);
+  const confirmationResolver = useRef(null);
 
   const notify = useCallback((message) => {
     setToast(message);
     window.clearTimeout(notify.timeout);
     notify.timeout = window.setTimeout(() => setToast(""), 2600);
+  }, []);
+
+  const confirmAction = useCallback((options) => {
+    if (confirmationResolver.current) {
+      confirmationResolver.current(false);
+    }
+    return new Promise((resolve) => {
+      confirmationResolver.current = resolve;
+      setConfirmation({
+        cancelLabel: options.cancelLabel || "Cancel",
+        confirmLabel: options.confirmLabel || "Confirm",
+        danger: Boolean(options.danger),
+        message: options.message || "",
+        title: options.title || "Confirm Action",
+      });
+    });
+  }, []);
+
+  const closeConfirmation = useCallback((confirmed) => {
+    const resolve = confirmationResolver.current;
+    confirmationResolver.current = null;
+    setConfirmation(null);
+    resolve?.(confirmed);
+  }, []);
+
+  useEffect(() => () => {
+    confirmationResolver.current?.(false);
+    confirmationResolver.current = null;
   }, []);
 
   const loadReferenceData = useCallback(async () => {
@@ -278,6 +308,7 @@ export default function App() {
               transactionPage={transactionPage}
               updateTransaction={updateTransaction}
               filterParams={filterParams}
+              confirmAction={confirmAction}
               notify={notify}
               reloadDashboard={loadDashboard}
             />
@@ -289,6 +320,7 @@ export default function App() {
             {activePage === "settings" && (
               <DefinitionsPage
                 mappingDraft={mappingDraft}
+                confirmAction={confirmAction}
                 notify={notify}
                 refs={refs}
                 reloadAll={loadAll}
@@ -299,6 +331,7 @@ export default function App() {
             {activePage === "maintenance" && (
               <MaintenancePage
                 notify={notify}
+                confirmAction={confirmAction}
                 reloadAll={loadAll}
                 reloadDashboard={loadDashboard}
                 reloadMaintenance={loadMaintenance}
@@ -349,6 +382,17 @@ export default function App() {
             </div>
           </div>
         </div>
+      )}
+      {confirmation && (
+        <ConfirmDialog
+          cancelLabel={confirmation.cancelLabel}
+          confirmLabel={confirmation.confirmLabel}
+          danger={confirmation.danger}
+          message={confirmation.message}
+          onCancel={() => closeConfirmation(false)}
+          onConfirm={() => closeConfirmation(true)}
+          title={confirmation.title}
+        />
       )}
       <div className={`toast ${toast ? "is-visible" : ""}`}>{toast}</div>
     </div>

--- a/frontend/src/components.jsx
+++ b/frontend/src/components.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 export function Select({ blank, defaultValue = "", name, onChange, options, required = false, value }) {
   const controlledProps = value === undefined ? { defaultValue } : { value };
   return (
@@ -23,4 +25,56 @@ export function Spinner() {
 
 export function Metric({ label, tone = "", value }) {
   return <div className="metric"><div className="metric-label">{label}</div><div className={`metric-value ${tone}`}>{value}</div></div>;
+}
+
+export function ConfirmDialog({
+  cancelLabel = "Cancel",
+  confirmLabel = "Confirm",
+  danger = false,
+  message,
+  onCancel,
+  onConfirm,
+  title = "Confirm Action",
+}) {
+  const cancelButtonRef = useRef(null);
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+    function handleKeyDown(event) {
+      if (event.key === "Escape") {
+        onCancel();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="modal-backdrop confirm-backdrop"
+      onMouseDown={(event) => event.target === event.currentTarget && onCancel()}
+      role="presentation"
+    >
+      <div
+        aria-labelledby="confirm-dialog-title"
+        aria-modal="true"
+        className={`confirm-modal ${danger ? "is-danger" : ""}`.trim()}
+        onMouseDown={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <div className="confirm-modal-header">
+          <h2 id="confirm-dialog-title">{title}</h2>
+        </div>
+        <div className="confirm-modal-message">{message}</div>
+        <div className="confirm-modal-actions">
+          <button className="link-button" onClick={onCancel} ref={cancelButtonRef} type="button">
+            {cancelLabel}
+          </button>
+          <button className={danger ? "danger-button" : "primary-action"} onClick={onConfirm} type="button">
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import createPlotlyComponent from "react-plotly.js/factory";
 import Plotly from "plotly.js-dist-min";
 import { AgGridReact } from "ag-grid-react";
@@ -1067,7 +1067,19 @@ function LockIcon({ locked }) {
   );
 }
 
+function InfoIcon() {
+  return (
+    <IconSvg>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 11v5" />
+      <path d="M12 8h.01" />
+    </IconSvg>
+  );
+}
+
 function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, refs, rows, updateTransaction }) {
+  const [rawDataPopover, setRawDataPopover] = useState(null);
+  const rawDataPopoverRef = useRef(null);
   const subcategoryOptions = useMemo(() => ["", ...refs.subcategories.map((item) => item.id)], [refs.subcategories]);
   const subcategoryLookup = useMemo(() => new Map(refs.subcategories.map((item) => [item.id, item])), [refs.subcategories]);
   const categoryLookup = useMemo(() => new Map(refs.categories.map((item) => [item.id, item])), [refs.categories]);
@@ -1080,8 +1092,74 @@ function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, re
     subcategory_id: row.subcategory?.id || "",
   })), [conflictIds, rows]);
 
+  useEffect(() => {
+    if (!rawDataPopover) {
+      return undefined;
+    }
+
+    function handlePointerDown(event) {
+      const popover = rawDataPopoverRef.current;
+      const eventPath = event.composedPath?.() || [];
+      const clickedPopover = popover && (popover.contains(event.target) || eventPath.includes(popover));
+      if (!clickedPopover) {
+        setRawDataPopover(null);
+      }
+    }
+
+    function handleKeyDown(event) {
+      if (event.key === "Escape") {
+        setRawDataPopover(null);
+      }
+    }
+
+    function closePopover() {
+      setRawDataPopover(null);
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("resize", closePopover);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", closePopover);
+    };
+  }, [rawDataPopover]);
+
+  const toggleRawDataPopover = useCallback((rowId, rawData, button) => {
+    const entries = rawDataEntries(rawData, hideAmounts);
+    if (!entries.length) {
+      setRawDataPopover(null);
+      return;
+    }
+    setRawDataPopover((current) => {
+      if (current?.rowId === rowId) {
+        return null;
+      }
+      return {
+        entries,
+        position: rawDataPopoverPosition(button.getBoundingClientRect()),
+        rowId,
+      };
+    });
+  }, [hideAmounts]);
+
   const columnDefs = useMemo(() => [
-    { field: "transaction_date", headerName: "Date", width: 120, sort: "desc" },
+    {
+      cellClass: "raw-data-grid-cell",
+      cellRenderer: (params) => (
+        <RawDataButton
+          onToggle={(button) => toggleRawDataPopover(params.data?.id, params.value, button)}
+          rawData={params.value}
+        />
+      ),
+      field: "raw_data",
+      headerName: "",
+      resizable: false,
+      sortable: false,
+      width: 52,
+    },
+    { field: "transaction_date", headerName: "Date", width: 120, initialSort: "desc" },
     { field: "description", headerName: "Description", flex: 2, minWidth: 260, wrapText: true, autoHeight: true },
     {
       cellClass: (params) => (Number(params.value) >= 0 ? "amount-income" : "amount-expense"),
@@ -1215,7 +1293,7 @@ function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, re
       valueFormatter: (params) => (params.value ? "Locked" : "Unlocked"),
       width: 96,
     },
-  ], [accountLookup, categoryLookup, defaultCurrency, hideAmounts, notify, refs.tags, subcategoryLookup, subcategoryOptions, updateTransaction]);
+  ], [accountLookup, categoryLookup, defaultCurrency, hideAmounts, notify, refs.tags, subcategoryLookup, subcategoryOptions, toggleRawDataPopover, updateTransaction]);
 
   async function onCellValueChanged(event) {
     if (event.oldValue === event.newValue || !["subcategory_id", "want_need_investment"].includes(event.colDef.field)) {
@@ -1246,6 +1324,13 @@ function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, re
         stopEditingWhenCellsLoseFocus
         theme={transactionGridTheme}
       />
+      {rawDataPopover && (
+        <RawDataPopover
+          entries={rawDataPopover.entries}
+          position={rawDataPopover.position}
+          ref={rawDataPopoverRef}
+        />
+      )}
     </div>
   );
 }
@@ -1705,6 +1790,145 @@ function WniCell({ value }) {
     return <span className="color-cell color-cell-muted"><span className="color-cell-label">Unassigned</span></span>;
   }
   return <span className="color-cell" style={colorPillStyle(wniColor(value))}><span className="color-cell-label">{titleCase(value)}</span></span>;
+}
+
+function RawDataButton({ onToggle, rawData }) {
+  const buttonRef = useRef(null);
+  const hasEntries = rawData && typeof rawData === "object" && Object.keys(rawData).length > 0;
+
+  function stopGridEvent(event) {
+    event.stopPropagation();
+  }
+
+  function togglePopover(event) {
+    event.stopPropagation();
+    if (buttonRef.current) {
+      onToggle(buttonRef.current);
+    }
+  }
+
+  return (
+    <div className="raw-data-cell-inner" onClick={stopGridEvent} onDoubleClick={stopGridEvent} onMouseDown={stopGridEvent} onPointerDown={stopGridEvent}>
+      <button
+        aria-haspopup="dialog"
+        aria-label={hasEntries ? "Show original transaction data" : "No original transaction data saved"}
+        className="raw-data-button"
+        disabled={!hasEntries}
+        onClick={togglePopover}
+        ref={buttonRef}
+        title={hasEntries ? "Show original data" : "No original data saved"}
+        type="button"
+      >
+        <InfoIcon />
+      </button>
+    </div>
+  );
+}
+
+const RawDataPopover = forwardRef(function RawDataPopover({ entries, position }, ref) {
+  function stopGridEvent(event) {
+    event.stopPropagation();
+  }
+
+  return (
+    <div
+      className="raw-data-popover"
+      onClick={stopGridEvent}
+      onDoubleClick={stopGridEvent}
+      onMouseDown={stopGridEvent}
+      onPointerDown={stopGridEvent}
+      ref={ref}
+      role="dialog"
+      style={{ left: position.left, top: position.top }}
+    >
+      <div className="raw-data-popover-header">
+        <strong>Original Data</strong>
+        <span>{entries.length.toLocaleString()} fields</span>
+      </div>
+      <dl className="raw-data-list">
+        {entries.map((entry) => (
+          <div className="raw-data-row" key={entry.key}>
+            <dt className="raw-data-key">{entry.key}</dt>
+            <dd className="raw-data-value">{entry.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+});
+
+function rawDataPopoverPosition(rect) {
+  const popoverWidth = 460;
+  const popoverHeight = 420;
+  const left = Math.min(
+    Math.max(12, rect.left),
+    Math.max(12, window.innerWidth - popoverWidth - 12),
+  );
+  const preferredTop = rect.bottom + 6;
+  const top = preferredTop + popoverHeight > window.innerHeight && rect.top > popoverHeight
+    ? rect.top - popoverHeight - 6
+    : preferredTop;
+  return { left, top: Math.max(12, top) };
+}
+
+function rawDataEntries(rawData, hideAmounts) {
+  if (!rawData || typeof rawData !== "object") {
+    return [];
+  }
+  const entries = Array.isArray(rawData)
+    ? rawData.map((value, index) => [`Item ${index + 1}`, value])
+    : Object.entries(rawData);
+  return entries.map(([key, value]) => ({
+    key: String(key),
+    value: formatRawDataValue(key, value, hideAmounts),
+  }));
+}
+
+function formatRawDataValue(key, value, hideAmounts) {
+  if (hideAmounts && rawDataFieldLooksMonetary(key)) {
+    return "--";
+  }
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function rawDataFieldLooksMonetary(key) {
+  const words = String(key || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  const wordTerms = new Set([
+    "amount",
+    "amt",
+    "balance",
+    "castka",
+    "credit",
+    "debit",
+    "expense",
+    "income",
+    "price",
+    "sum",
+    "suma",
+    "total",
+    "zustatek",
+  ]);
+  if (words.some((word) => wordTerms.has(word))) {
+    return true;
+  }
+  const normalized = normalizeName(key);
+  return ["amount", "balance", "castka", "expense", "income", "price", "suma", "total", "zustatek"]
+    .some((term) => normalized.includes(term));
 }
 
 function EditableTagCell({ allTags, notify, row, tags, updateTransaction }) {

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -87,6 +87,7 @@ const emptyKeywordDraft = {
 };
 
 export default function DashboardPage({
+  confirmAction,
   filters,
   filterParams,
   hideAmounts,
@@ -247,7 +248,12 @@ export default function DashboardPage({
       return;
     }
     const lockedText = recategorizeLocked ? " Locked transactions included by the current filters will be reset and recategorized." : "";
-    if (!window.confirm(`Recategorize ${transactionPage.count.toLocaleString()} filtered transactions?${lockedText}`)) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Recategorize",
+      message: `Recategorize ${transactionPage.count.toLocaleString()} filtered transactions?${lockedText}`,
+      title: "Recategorize Transactions",
+    });
+    if (!confirmed) {
       return;
     }
     setRecategorizing(true);

--- a/frontend/src/pages/DefinitionsPage.jsx
+++ b/frontend/src/pages/DefinitionsPage.jsx
@@ -33,7 +33,7 @@ const defaultCurrencyOptions = [
   { code: "GBP", name: "British Pound" },
 ];
 
-export default function DefinitionsPage({ mappingDraft, notify, refs, reloadAll, reloadDashboard, setMappingDraft }) {
+export default function DefinitionsPage({ confirmAction, mappingDraft, notify, refs, reloadAll, reloadDashboard, setMappingDraft }) {
   const [editingItems, setEditingItems] = useState({});
 
   function editItem(endpoint, item) {
@@ -53,22 +53,22 @@ export default function DefinitionsPage({ mappingDraft, notify, refs, reloadAll,
       <CollapsiblePanel defaultExpanded storageId="app-settings" subtitle="Currency, exchange rates, and transfer automation" title="App Settings" wide>
         <SettingsForm notify={notify} refs={refs} reloadAll={reloadAll} reloadDashboard={reloadDashboard} settings={refs.settings} />
       </CollapsiblePanel>
-      <DefinitionPanel defaultExpanded endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
+      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
         <MappingForm clearEditing={() => clearEditing("/csv-mappings/")} draft={mappingDraft} editingItem={editingItems["/csv-mappings/"]} notify={notify} refs={refs} reloadAll={reloadAll} setDraft={setMappingDraft} />
       </DefinitionPanel>
-      <DefinitionPanel defaultExpanded endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
+      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
         <AccountForm clearEditing={() => clearEditing("/bank-accounts/")} editingItem={editingItems["/bank-accounts/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel endpoint="/categories/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Categories} items={refs.categories} notify={notify} onDeleted={() => clearEditing("/categories/")} onEdit={(item) => editItem("/categories/", item)} reloadAll={reloadAll} subtitle="Top-level reporting buckets" title="Categories">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/categories/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Categories} items={refs.categories} notify={notify} onDeleted={() => clearEditing("/categories/")} onEdit={(item) => editItem("/categories/", item)} reloadAll={reloadAll} subtitle="Top-level reporting buckets" title="Categories">
         <SimpleForm clearEditing={() => clearEditing("/categories/")} editingItem={editingItems["/categories/"]} endpoint="/categories/" entityLabel="Category" fields={[["name", "Name", true], ["color", "Color"], ["description", "Description"]]} items={refs.categories} notify={notify} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel endpoint="/subcategories/" formatter={(item) => [item.name, item.category?.name || ""]} helpText={definitionHelp.Subcategories} items={refs.subcategories} notify={notify} onDeleted={() => clearEditing("/subcategories/")} onEdit={(item) => editItem("/subcategories/", item)} reloadAll={reloadAll} subtitle="Assignable category detail" title="Subcategories">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/subcategories/" formatter={(item) => [item.name, item.category?.name || ""]} helpText={definitionHelp.Subcategories} items={refs.subcategories} notify={notify} onDeleted={() => clearEditing("/subcategories/")} onEdit={(item) => editItem("/subcategories/", item)} reloadAll={reloadAll} subtitle="Assignable category detail" title="Subcategories">
         <SubcategoryForm clearEditing={() => clearEditing("/subcategories/")} editingItem={editingItems["/subcategories/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel endpoint="/tags/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Tags} items={refs.tags} notify={notify} onDeleted={() => clearEditing("/tags/")} onEdit={(item) => editItem("/tags/", item)} reloadAll={reloadAll} subtitle="Flexible transaction labels" title="Tags">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/tags/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Tags} items={refs.tags} notify={notify} onDeleted={() => clearEditing("/tags/")} onEdit={(item) => editItem("/tags/", item)} reloadAll={reloadAll} subtitle="Flexible transaction labels" title="Tags">
         <SimpleForm clearEditing={() => clearEditing("/tags/")} editingItem={editingItems["/tags/"]} endpoint="/tags/" entityLabel="Tag" fields={[["name", "Name", true], ["color", "Color"], ["description", "Description"]]} items={refs.tags} notify={notify} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel defaultExpanded endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
+      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
         <KeywordForm clearEditing={() => clearEditing("/keywords/")} editingItem={editingItems["/keywords/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
     </div>
@@ -332,7 +332,7 @@ function CollapsiblePanel({ children, count, defaultExpanded = false, helpText, 
   );
 }
 
-function DefinitionPanel({ children, defaultExpanded = false, endpoint, formatter, helpText, items, notify, onDeleted, onEdit, reloadAll, subtitle, title, wide = false }) {
+function DefinitionPanel({ children, confirmAction, defaultExpanded = false, endpoint, formatter, helpText, items, notify, onDeleted, onEdit, reloadAll, subtitle, title, wide = false }) {
   const storageId = endpoint.replace(/(^\/|\/$)/g, "").replace(/\W+/g, "-");
   return (
     <CollapsiblePanel count={items.length} defaultExpanded={defaultExpanded} helpText={helpText} storageId={storageId} subtitle={subtitle} title={title} wide={wide}>
@@ -349,7 +349,7 @@ function DefinitionPanel({ children, defaultExpanded = false, endpoint, formatte
               <div className="item-actions">
                 {item.color && <span className="swatch" style={{ background: item.color }} />}
                 <button className="edit-button" onClick={() => onEdit(item)} type="button">Edit</button>
-                <DeleteButton endpoint={`${endpoint}${item.id}/`} name={itemTitle} notify={notify} onDeleted={onDeleted} reloadAll={reloadAll} />
+                <DeleteButton confirmAction={confirmAction} endpoint={`${endpoint}${item.id}/`} name={itemTitle} notify={notify} onDeleted={onDeleted} reloadAll={reloadAll} />
               </div>
             </div>
           );
@@ -368,10 +368,16 @@ function HelpTooltip({ text }) {
   );
 }
 
-function DeleteButton({ endpoint, name, notify, onDeleted, reloadAll }) {
+function DeleteButton({ confirmAction, endpoint, name, notify, onDeleted, reloadAll }) {
   const [deleting, setDeleting] = useState(false);
   async function remove() {
-    if (!window.confirm(`Delete ${name}?`)) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Delete",
+      danger: true,
+      message: `Delete ${name}?`,
+      title: "Delete Record",
+    });
+    if (!confirmed) {
       return;
     }
     setDeleting(true);

--- a/frontend/src/pages/MaintenancePage.jsx
+++ b/frontend/src/pages/MaintenancePage.jsx
@@ -4,7 +4,7 @@ import { apiDelete, apiGet, apiPost } from "../api.js";
 import { LoadingButton, Metric } from "../components.jsx";
 import { formatCount } from "../shared.js";
 
-export default function MaintenancePage({ notify, reloadAll, reloadDashboard, reloadMaintenance, summary }) {
+export default function MaintenancePage({ confirmAction, notify, reloadAll, reloadDashboard, reloadMaintenance, summary }) {
   const [deleting, setDeleting] = useState("");
   const [restoreFile, setRestoreFile] = useState(null);
   const [safeBusy, setSafeBusy] = useState("");
@@ -96,7 +96,13 @@ export default function MaintenancePage({ notify, reloadAll, reloadDashboard, re
   }
 
   async function deleteMaintenanceData(action) {
-    if (!window.confirm(`${action.title}?\n\n${action.description}`)) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Delete",
+      danger: true,
+      message: `${action.title}?\n\n${action.description}`,
+      title: action.title,
+    });
+    if (!confirmed) {
       return;
     }
     setDeleting(action.phrase);
@@ -153,12 +159,13 @@ export default function MaintenancePage({ notify, reloadAll, reloadDashboard, re
   }
 
   async function restoreSavedBackup(backup) {
-    if (
-      !window.confirm(
-        `Restore ${backup.filename}?\n\nThis replaces the current local database. `
-          + "A pre-restore backup will be saved automatically."
-      )
-    ) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Restore",
+      danger: true,
+      message: `Restore ${backup.filename}?\n\nThis replaces the current local database. A pre-restore backup will be saved automatically.`,
+      title: "Restore Backup",
+    });
+    if (!confirmed) {
       return;
     }
     setBackupAction(`restore:${backup.filename}`);
@@ -178,11 +185,13 @@ export default function MaintenancePage({ notify, reloadAll, reloadDashboard, re
   }
 
   async function deleteSavedBackup(backup) {
-    if (
-      !window.confirm(
-        `Delete ${backup.filename}?\n\nThis removes the saved backup file. The current database is not changed.`
-      )
-    ) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Delete",
+      danger: true,
+      message: `Delete ${backup.filename}?\n\nThis removes the saved backup file. The current database is not changed.`,
+      title: "Delete Backup",
+    });
+    if (!confirmed) {
       return;
     }
     setBackupAction(`delete:${backup.filename}`);
@@ -205,12 +214,13 @@ export default function MaintenancePage({ notify, reloadAll, reloadDashboard, re
     if (!restoreFile) {
       return;
     }
-    if (
-      !window.confirm(
-        "Restore database backup?\n\nThis replaces the current local database. "
-          + "A pre-restore backup will be saved automatically."
-      )
-    ) {
+    const confirmed = await confirmAction({
+      confirmLabel: "Restore",
+      danger: true,
+      message: "Restore database backup?\n\nThis replaces the current local database. A pre-restore backup will be saved automatically.",
+      title: "Restore Database",
+    });
+    if (!confirmed) {
       return;
     }
     setSafeBusy("restore");

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2339,6 +2339,126 @@ select option {
   justify-content: center;
 }
 
+.transaction-grid .raw-data-grid-cell {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 0;
+}
+
+.raw-data-cell-inner {
+  display: grid;
+  place-items: center;
+  width: 100%;
+}
+
+.raw-data-button {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 30px;
+  justify-content: center;
+  padding: 0;
+  width: 30px;
+}
+
+.raw-data-button:hover,
+.raw-data-button:focus {
+  background: var(--soft-hover);
+  border-color: var(--action);
+  color: var(--action);
+  outline: none;
+}
+
+.raw-data-button:disabled,
+.raw-data-button:disabled:hover,
+.raw-data-button:disabled:focus {
+  background: transparent;
+  border-color: transparent;
+  color: var(--muted);
+  cursor: default;
+  opacity: 0.42;
+}
+
+.raw-data-popover {
+  position: fixed;
+  z-index: 45;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: min(460px, calc(100vw - 24px));
+  max-height: min(420px, calc(100vh - 24px));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--floating-shadow);
+  padding: 10px;
+}
+
+.raw-data-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 2px 9px;
+  border-bottom: 1px solid var(--border);
+}
+
+.raw-data-popover-header strong {
+  font-size: 0.92rem;
+}
+
+.raw-data-popover-header span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.raw-data-list {
+  display: grid;
+  gap: 0;
+  min-height: 0;
+  margin: 0;
+  overflow: auto;
+}
+
+.raw-data-row {
+  display: grid;
+  grid-template-columns: minmax(112px, 0.42fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 2px;
+  border-bottom: 1px solid var(--border);
+}
+
+.raw-data-row:last-child {
+  border-bottom: 0;
+}
+
+.raw-data-key,
+.raw-data-value {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.raw-data-key {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 760;
+  line-height: 1.35;
+}
+
+.raw-data-value {
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
 .lock-cell-button {
   align-items: center;
   background: transparent;
@@ -3697,8 +3817,13 @@ td {
   .dashboard-action-row,
   .bulk-assign-buttons,
   .uncategorized-sample-header,
-  .uncategorized-sample-row {
+  .uncategorized-sample-row,
+  .raw-data-row {
     grid-template-columns: 1fr;
+  }
+
+  .raw-data-row {
+    gap: 3px;
   }
 
   .uncategorized-keyword-form .form-field:nth-child(2),

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -411,6 +411,43 @@ h2 {
   min-height: 38px;
 }
 
+.confirm-modal {
+  width: min(460px, 100%);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--floating-shadow);
+  padding: 16px;
+}
+
+.confirm-modal.is-danger {
+  border-color: color-mix(in srgb, var(--red) 44%, var(--border));
+}
+
+.confirm-modal-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.confirm-modal-message {
+  margin: 12px 0 16px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.45;
+  white-space: pre-line;
+}
+
+.confirm-modal-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px;
+}
+
+.confirm-modal-actions button {
+  min-height: 38px;
+}
+
 .definition-modal {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;


### PR DESCRIPTION
## Summary

- Fix packaged Electron app icon handling so the installed app uses the Cashmoney icon.
- Replace native `window.confirm` dialogs with an in-app confirmation modal to avoid Electron input/focus issues after delete/restore actions.
- Add a dashboard info column that opens a scrollable popover with the original imported transaction data.
- Format raw transaction data as readable key/value rows, preserve blank values, and mask hidden monetary fields with `--`.

## Testing

- `.\build_frontend.bat --skip-setup`