### PR TITLE
Improve finance workflows, definitions UI, and local maintenance tools

### DIFF
--- a/backend/finance/services.py
+++ b/backend/finance/services.py
@@ -1553,29 +1553,49 @@ class CSVImportService:
         return transaction_obj, categorization
 
 
-def normalized_uncategorized_group_key(transaction_obj):
-    text = transaction_obj.description or transaction_obj.counterparty_name or ""
+def strict_categorization_text(transaction_data, csv_mapping):
+    parts = []
+    for field_name in csv_mapping.get_categorization_fields():
+        value = transaction_data.get(field_name)
+        if value not in (None, ""):
+            parts.append(str(value))
+    return " | ".join(parts)
+
+
+def uncategorized_suggestion_text(transaction_obj):
+    csv_mapping = (
+        transaction_obj.bank_account.default_csv_mapping
+        if transaction_obj.bank_account
+        else None
+    )
+    if not csv_mapping:
+        return ""
+
+    mapped_values = mapped_transaction_values_from_raw_data(
+        transaction_obj, csv_mapping
+    )
+    data = {}
+    for field_name in RECATEGORIZABLE_TRANSACTION_FIELDS:
+        data[field_name] = mapped_values.get(
+            field_name, getattr(transaction_obj, field_name)
+        )
+    return strict_categorization_text(data, csv_mapping)
+
+
+def normalized_uncategorized_group_key(text):
     normalized = re.sub(r"[^\w]+", " ", str(text).casefold())
     normalized = normalized.replace("_", " ")
     normalized = re.sub(r"\s+", " ", normalized).strip()
-    return normalized or "__no_description__"
+    return normalized
 
 
-def transaction_suggestion_label(transaction_obj):
-    label = (
-        transaction_obj.description
-        or transaction_obj.counterparty_name
-        or transaction_obj.transaction_type
-        or "No description"
-    )
+def transaction_suggestion_label(categorization_text):
+    label = categorization_text or "No categorization text"
     return re.sub(r"\s+", " ", str(label)).strip() or "No description"
 
 
-def group_suggestion_label(transactions):
-    labels = [
-        transaction_suggestion_label(transaction_obj)
-        for transaction_obj in transactions
-    ]
+def group_suggestion_label(categorization_texts):
+    labels = [transaction_suggestion_label(text) for text in categorization_texts]
     return sorted(labels, key=lambda label: (label.casefold(), label))[0]
 
 
@@ -1591,14 +1611,18 @@ def suggested_keyword_name(label):
 
 
 def build_uncategorized_suggestions(queryset, default_currency, limit=8):
-    groups = defaultdict(list)
+    groups = defaultdict(lambda: {"texts": [], "transactions": []})
     for transaction_obj in queryset:
-        groups[normalized_uncategorized_group_key(transaction_obj)].append(
-            transaction_obj
-        )
+        categorization_text = uncategorized_suggestion_text(transaction_obj)
+        group_key = normalized_uncategorized_group_key(categorization_text)
+        if not group_key:
+            continue
+        groups[group_key]["texts"].append(categorization_text)
+        groups[group_key]["transactions"].append(transaction_obj)
 
     suggestions = []
-    for group_key, transactions in groups.items():
+    for group_key, group in groups.items():
+        transactions = group["transactions"]
         sorted_transactions = sorted(
             transactions,
             key=lambda item: (
@@ -1607,7 +1631,7 @@ def build_uncategorized_suggestions(queryset, default_currency, limit=8):
             ),
             reverse=True,
         )
-        label = group_suggestion_label(transactions)
+        label = group_suggestion_label(group["texts"])
         amount_values = [
             transaction_priority_amount(transaction_obj, default_currency)
             for transaction_obj in transactions
@@ -1619,7 +1643,7 @@ def build_uncategorized_suggestions(queryset, default_currency, limit=8):
         )
         transaction_count = len(transactions)
         reason = (
-            "Repeated description"
+            "Repeated categorization text"
             if transaction_count > 1
             else "Large uncategorized transaction"
         )
@@ -1672,7 +1696,9 @@ def build_uncategorized_suggestions(queryset, default_currency, limit=8):
     )
     return {
         "count": len(suggestions),
-        "transaction_count": sum(len(transactions) for transactions in groups.values()),
+        "transaction_count": sum(
+            len(group["transactions"]) for group in groups.values()
+        ),
         "suggestions": suggestions[:limit],
     }
 

--- a/backend/finance/tests.py
+++ b/backend/finance/tests.py
@@ -1405,20 +1405,36 @@ class APITests(FinanceTestCase):
         Transaction.objects.create(
             bank_account=self.account,
             transaction_date="2026-01-02",
-            description="Coffee Shop",
+            description="",
             amount=Decimal("-10.00"),
+            raw_data={"Description": "Coffee Shop", "Counterparty": ""},
         )
         Transaction.objects.create(
             bank_account=self.account,
             transaction_date="2026-01-03",
-            description="coffee   shop",
+            description="",
             amount=Decimal("-12.00"),
+            raw_data={"Description": "coffee   shop", "Counterparty": ""},
         )
         large_transaction = Transaction.objects.create(
             bank_account=self.account,
             transaction_date="2026-01-04",
-            description="Annual Insurance",
+            description="",
             amount=Decimal("-500.00"),
+            raw_data={"Description": "Annual Insurance", "Counterparty": ""},
+        )
+        Transaction.objects.create(
+            bank_account=self.account,
+            transaction_date="2026-01-04",
+            description="",
+            counterparty_name="",
+            transaction_type="Odchozí úhrada",
+            amount=Decimal("-25.00"),
+            raw_data={
+                "Description": "",
+                "Counterparty": "",
+                "Typ transakce": "Odchozí úhrada",
+            },
         )
         Transaction.objects.create(
             bank_account=self.account,
@@ -1452,7 +1468,7 @@ class APITests(FinanceTestCase):
         self.assertEqual(payload["count"], 2)
         self.assertEqual(
             [suggestion["reason"] for suggestion in payload["suggestions"]],
-            ["Large uncategorized transaction", "Repeated description"],
+            ["Large uncategorized transaction", "Repeated categorization text"],
         )
         self.assertEqual(
             payload["suggestions"][0]["transaction_ids"],

--- a/backend/finance/views.py
+++ b/backend/finance/views.py
@@ -1081,7 +1081,12 @@ class UncategorizedSuggestionView(JsonView):
                 is_ignored=False,
                 is_categorization_locked=False,
             )
-            .select_related("bank_account", "subcategory", "subcategory__category")
+            .select_related(
+                "bank_account",
+                "bank_account__default_csv_mapping",
+                "subcategory",
+                "subcategory__category",
+            )
             .prefetch_related("tags")
         )
         return json_response(

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1084,6 +1084,11 @@ function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, re
   const subcategoryLookup = useMemo(() => new Map(refs.subcategories.map((item) => [item.id, item])), [refs.subcategories]);
   const categoryLookup = useMemo(() => new Map(refs.categories.map((item) => [item.id, item])), [refs.categories]);
   const accountLookup = useMemo(() => new Map(refs.accounts.map((item) => [item.id, item.name])), [refs.accounts]);
+  const accountMappingLookup = useMemo(
+    () => new Map(refs.accounts.map((item) => [item.id, item.default_csv_mapping?.id || ""])),
+    [refs.accounts],
+  );
+  const mappingLookup = useMemo(() => new Map(refs.mappings.map((item) => [item.id, item])), [refs.mappings]);
 
   const rowData = useMemo(() => rows.map((row) => ({
     ...row,
@@ -1126,30 +1131,32 @@ function TransactionGrid({ conflictIds, defaultCurrency, hideAmounts, notify, re
     };
   }, [rawDataPopover]);
 
-  const toggleRawDataPopover = useCallback((rowId, rawData, button) => {
-    const entries = rawDataEntries(rawData, hideAmounts);
+  const toggleRawDataPopover = useCallback((row, rawData, button) => {
+    const mappingId = accountMappingLookup.get(row?.account_id || row?.bank_account?.id || "");
+    const mapping = mappingLookup.get(mappingId);
+    const entries = rawDataEntries(rawData, hideAmounts, categorizationRawDataKeys(mapping));
     if (!entries.length) {
       setRawDataPopover(null);
       return;
     }
     setRawDataPopover((current) => {
-      if (current?.rowId === rowId) {
+      if (current?.rowId === row?.id) {
         return null;
       }
       return {
         entries,
         position: rawDataPopoverPosition(button.getBoundingClientRect()),
-        rowId,
+        rowId: row?.id,
       };
     });
-  }, [hideAmounts]);
+  }, [accountMappingLookup, hideAmounts, mappingLookup]);
 
   const columnDefs = useMemo(() => [
     {
       cellClass: "raw-data-grid-cell",
       cellRenderer: (params) => (
         <RawDataButton
-          onToggle={(button) => toggleRawDataPopover(params.data?.id, params.value, button)}
+          onToggle={(button) => toggleRawDataPopover(params.data, params.value, button)}
           rawData={params.value}
         />
       ),
@@ -1847,8 +1854,11 @@ const RawDataPopover = forwardRef(function RawDataPopover({ entries, position },
       </div>
       <dl className="raw-data-list">
         {entries.map((entry) => (
-          <div className="raw-data-row" key={entry.key}>
-            <dt className="raw-data-key">{entry.key}</dt>
+          <div className={`raw-data-row ${entry.isCategorizationField ? "is-categorization-field" : ""}`.trim()} key={entry.key}>
+            <dt className="raw-data-key">
+              <span>{entry.key}</span>
+              {entry.isCategorizationField ? <span className="raw-data-badge">Categorization</span> : null}
+            </dt>
             <dd className="raw-data-value">{entry.value}</dd>
           </div>
         ))}
@@ -1871,7 +1881,7 @@ function rawDataPopoverPosition(rect) {
   return { left, top: Math.max(12, top) };
 }
 
-function rawDataEntries(rawData, hideAmounts) {
+function rawDataEntries(rawData, hideAmounts, highlightedKeys = new Set()) {
   if (!rawData || typeof rawData !== "object") {
     return [];
   }
@@ -1879,9 +1889,32 @@ function rawDataEntries(rawData, hideAmounts) {
     ? rawData.map((value, index) => [`Item ${index + 1}`, value])
     : Object.entries(rawData);
   return entries.map(([key, value]) => ({
+    isCategorizationField: highlightedKeys.has(String(key)),
     key: String(key),
     value: formatRawDataValue(key, value, hideAmounts),
   }));
+}
+
+function categorizationRawDataKeys(mapping) {
+  const highlightedKeys = new Set();
+  if (!mapping?.column_map || !Array.isArray(mapping.categorization_fields)) {
+    return highlightedKeys;
+  }
+  mapping.categorization_fields.forEach((field) => {
+    coerceRawDataColumns(mapping.column_map[field]).forEach((column) => {
+      if (column) {
+        highlightedKeys.add(column);
+      }
+    });
+  });
+  return highlightedKeys;
+}
+
+function coerceRawDataColumns(value) {
+  if (!value) {
+    return [];
+  }
+  return Array.isArray(value) ? value.map((item) => String(item)) : [String(value)];
 }
 
 function formatRawDataValue(key, value, hideAmounts) {

--- a/frontend/src/pages/DefinitionsPage.jsx
+++ b/frontend/src/pages/DefinitionsPage.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { AgGridReact } from "ag-grid-react";
+import { AllCommunityModule, ModuleRegistry, themeQuartz } from "ag-grid-community";
 
 import { apiDelete, apiGet, apiPatch, apiPost } from "../api.js";
 import { LoadingButton, Select } from "../components.jsx";
@@ -25,6 +27,46 @@ import {
   validateRequiredFields,
   wniOptions,
 } from "../shared.js";
+
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+const definitionGridTheme = themeQuartz
+  .withParams({
+    accentColor: "var(--action)",
+    backgroundColor: "var(--surface)",
+    borderColor: "var(--border)",
+    browserColorScheme: "dark",
+    cellTextColor: "var(--text)",
+    chromeBackgroundColor: "var(--subtle-bg)",
+    dataBackgroundColor: "var(--surface)",
+    foregroundColor: "var(--text)",
+    headerBackgroundColor: "var(--subtle-bg)",
+    headerTextColor: "var(--text)",
+    menuBackgroundColor: "var(--surface)",
+    oddRowBackgroundColor: "var(--surface)",
+    rowHoverColor: "var(--surface-2)",
+    selectedRowBackgroundColor: "var(--focus-ring)",
+    wrapperBorder: "1px solid var(--border)",
+    wrapperBorderRadius: "8px",
+  }, "dark")
+  .withParams({
+    accentColor: "var(--action)",
+    backgroundColor: "var(--surface)",
+    borderColor: "var(--border)",
+    browserColorScheme: "light",
+    cellTextColor: "var(--text)",
+    chromeBackgroundColor: "var(--subtle-bg)",
+    dataBackgroundColor: "var(--surface)",
+    foregroundColor: "var(--text)",
+    headerBackgroundColor: "var(--subtle-bg)",
+    headerTextColor: "var(--text)",
+    menuBackgroundColor: "var(--surface)",
+    oddRowBackgroundColor: "var(--surface)",
+    rowHoverColor: "var(--surface-2)",
+    selectedRowBackgroundColor: "var(--focus-ring)",
+    wrapperBorder: "1px solid var(--border)",
+    wrapperBorderRadius: "8px",
+  }, "light");
 
 const defaultCurrencyOptions = [
   { code: "CZK", name: "Czech Koruna" },
@@ -53,22 +95,22 @@ export default function DefinitionsPage({ confirmAction, mappingDraft, notify, r
       <CollapsiblePanel storageId="app-settings" subtitle="Currency, exchange rates, and transfer automation" title="App Settings" wide>
         <SettingsForm notify={notify} refs={refs} reloadAll={reloadAll} reloadDashboard={reloadDashboard} settings={refs.settings} />
       </CollapsiblePanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} listRenderer={CsvMappingDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
         <MappingForm clearEditing={() => clearEditing("/csv-mappings/")} draft={mappingDraft} editingItem={editingItems["/csv-mappings/"]} notify={notify} refs={refs} reloadAll={reloadAll} setDraft={setMappingDraft} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} listRenderer={BankAccountDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
         <AccountForm clearEditing={() => clearEditing("/bank-accounts/")} editingItem={editingItems["/bank-accounts/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/categories/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Categories} items={refs.categories} notify={notify} onDeleted={() => clearEditing("/categories/")} onEdit={(item) => editItem("/categories/", item)} reloadAll={reloadAll} subtitle="Top-level reporting buckets" title="Categories">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/categories/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Categories} items={refs.categories} listRenderer={CategoryDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/categories/")} onEdit={(item) => editItem("/categories/", item)} reloadAll={reloadAll} subtitle="Top-level reporting buckets" title="Categories">
         <SimpleForm clearEditing={() => clearEditing("/categories/")} editingItem={editingItems["/categories/"]} endpoint="/categories/" entityLabel="Category" fields={[["name", "Name", true], ["color", "Color"], ["description", "Description"]]} items={refs.categories} notify={notify} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/subcategories/" formatter={(item) => [item.name, item.category?.name || ""]} helpText={definitionHelp.Subcategories} items={refs.subcategories} notify={notify} onDeleted={() => clearEditing("/subcategories/")} onEdit={(item) => editItem("/subcategories/", item)} reloadAll={reloadAll} subtitle="Assignable category detail" title="Subcategories">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/subcategories/" formatter={(item) => [item.name, item.category?.name || ""]} helpText={definitionHelp.Subcategories} items={refs.subcategories} listRenderer={SubcategoryDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/subcategories/")} onEdit={(item) => editItem("/subcategories/", item)} reloadAll={reloadAll} subtitle="Assignable category detail" title="Subcategories">
         <SubcategoryForm clearEditing={() => clearEditing("/subcategories/")} editingItem={editingItems["/subcategories/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/tags/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Tags} items={refs.tags} notify={notify} onDeleted={() => clearEditing("/tags/")} onEdit={(item) => editItem("/tags/", item)} reloadAll={reloadAll} subtitle="Flexible transaction labels" title="Tags">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/tags/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Tags} items={refs.tags} listRenderer={TagDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/tags/")} onEdit={(item) => editItem("/tags/", item)} reloadAll={reloadAll} subtitle="Flexible transaction labels" title="Tags">
         <SimpleForm clearEditing={() => clearEditing("/tags/")} editingItem={editingItems["/tags/"]} endpoint="/tags/" entityLabel="Tag" fields={[["name", "Name", true], ["color", "Color"], ["description", "Description"]]} items={refs.tags} notify={notify} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} listRenderer={KeywordDefinitionGrid} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
         <KeywordForm clearEditing={() => clearEditing("/keywords/")} editingItem={editingItems["/keywords/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
     </div>
@@ -332,31 +374,239 @@ function CollapsiblePanel({ children, count, defaultExpanded = false, helpText, 
   );
 }
 
-function DefinitionPanel({ children, confirmAction, defaultExpanded = false, endpoint, formatter, helpText, items, notify, onDeleted, onEdit, reloadAll, subtitle, title, wide = false }) {
+function DefinitionPanel({ children, confirmAction, defaultExpanded = false, endpoint, formatter, helpText, items, listRenderer: ListRenderer, notify, onDeleted, onEdit, reloadAll, subtitle, title, wide = false }) {
   const storageId = endpoint.replace(/(^\/|\/$)/g, "").replace(/\W+/g, "-");
   return (
     <CollapsiblePanel count={items.length} defaultExpanded={defaultExpanded} helpText={helpText} storageId={storageId} subtitle={subtitle} title={title} wide={wide}>
       {children}
-      <div className="item-list">
-        {items.length ? items.map((item) => {
-          const [itemTitle, subtitle] = formatter(item);
-          return (
-            <div className="item-row" key={item.id}>
-              <div>
-                <div className="item-title">{itemTitle}</div>
-                <div className="item-subtitle">{subtitle}</div>
-              </div>
-              <div className="item-actions">
-                {item.color && <span className="swatch" style={{ background: item.color }} />}
-                <button className="edit-button" onClick={() => onEdit(item)} type="button">Edit</button>
-                <DeleteButton confirmAction={confirmAction} endpoint={`${endpoint}${item.id}/`} name={itemTitle} notify={notify} onDeleted={onDeleted} reloadAll={reloadAll} />
-              </div>
-            </div>
-          );
-        }) : <div className="muted">No records yet.</div>}
-      </div>
+      {ListRenderer ? (
+        <ListRenderer confirmAction={confirmAction} endpoint={endpoint} formatter={formatter} items={items} notify={notify} onDeleted={onDeleted} onEdit={onEdit} reloadAll={reloadAll} />
+      ) : (
+        <DefaultDefinitionList confirmAction={confirmAction} endpoint={endpoint} formatter={formatter} items={items} notify={notify} onDeleted={onDeleted} onEdit={onEdit} reloadAll={reloadAll} />
+      )}
     </CollapsiblePanel>
   );
+}
+
+function DefaultDefinitionList({ confirmAction, endpoint, formatter, items, notify, onDeleted, onEdit, reloadAll }) {
+  return (
+    <div className="item-list">
+      {items.length ? items.map((item) => {
+        const [itemTitle, subtitle] = formatter(item);
+        return (
+          <div className="item-row" key={item.id}>
+            <div>
+              <div className="item-title">{itemTitle}</div>
+              <div className="item-subtitle">{subtitle}</div>
+            </div>
+            <div className="item-actions">
+              {item.color && <span className="swatch" style={{ background: item.color }} />}
+              <button className="edit-button" onClick={() => onEdit(item)} type="button">Edit</button>
+              <DeleteButton confirmAction={confirmAction} endpoint={`${endpoint}${item.id}/`} name={itemTitle} notify={notify} onDeleted={onDeleted} reloadAll={reloadAll} />
+            </div>
+          </div>
+        );
+      }) : <div className="muted">No records yet.</div>}
+    </div>
+  );
+}
+
+function definitionGridHeight(rowCount) {
+  return Math.min(560, Math.max(198, 48 + (Math.max(rowCount, 1) * 52)));
+}
+
+function definitionActionColumn({ confirmAction, endpoint, nameGetter = (item) => item.name, notify, onDeleted, onEdit, reloadAll }) {
+  return {
+    cellClass: "definition-grid-actions-cell",
+    cellRenderer: (params) => (
+      <div className="definition-grid-actions">
+        <button className="edit-button" onClick={() => onEdit(params.data)} type="button">Edit</button>
+        <DeleteButton confirmAction={confirmAction} endpoint={`${endpoint}${params.data.id}/`} name={nameGetter(params.data)} notify={notify} onDeleted={onDeleted} reloadAll={reloadAll} />
+      </div>
+    ),
+    headerName: "",
+    minWidth: 150,
+    pinned: "right",
+    resizable: false,
+    sortable: false,
+    width: 150,
+  };
+}
+
+function DefinitionAgGridList({ className = "", columnDefs, items, rowData }) {
+  if (!items.length) {
+    return <div className="muted definition-grid-empty">No records yet.</div>;
+  }
+
+  return (
+    <div className={`definition-grid-list ${className}`.trim()} style={{ height: definitionGridHeight(rowData.length) }}>
+      <AgGridReact
+        columnDefs={columnDefs}
+        defaultColDef={{ filter: true, resizable: true, sortable: true }}
+        enableCellTextSelection
+        ensureDomOrder
+        rowData={rowData}
+        rowHeight={52}
+        theme={definitionGridTheme}
+      />
+    </div>
+  );
+}
+
+function DefinitionGridColorCell({ value }) {
+  if (!value) {
+    return <span className="definition-grid-color-empty">None</span>;
+  }
+  return (
+    <span className="definition-grid-color">
+      <span className="definition-grid-color-swatch" style={{ background: value }} />
+      <span>{value}</span>
+    </span>
+  );
+}
+
+function CsvMappingDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const rowData = useMemo(() => items.map((item) => ({
+    ...item,
+    categorization_fields_text: (item.categorization_fields || []).map((field) => fieldLabel(field)).join(", "),
+    delimiter_text: item.delimiter === "\t" ? "\\t" : item.delimiter,
+  })), [items]);
+  const columnDefs = useMemo(() => [
+    { field: "name", flex: 1.2, headerName: "Name", minWidth: 220 },
+    { field: "default_currency", headerName: "Currency", minWidth: 115, width: 120 },
+    { field: "delimiter_text", headerName: "Delimiter", minWidth: 110, width: 115 },
+    { field: "date_format", headerName: "Date Format", minWidth: 145, width: 150 },
+    { field: "encoding", headerName: "Encoding", minWidth: 130, width: 140 },
+    { field: "header_row", headerName: "Header Row", minWidth: 120, width: 125 },
+    { field: "categorization_fields_text", flex: 1.4, headerName: "Categorization Fields", minWidth: 240, tooltipField: "categorization_fields_text" },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="csv-mapping-definition-grid" columnDefs={columnDefs} items={items} rowData={rowData} />;
+}
+
+function BankAccountDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const rowData = useMemo(() => items.map((item) => ({
+    ...item,
+    default_mapping_text: item.default_csv_mapping?.name || "No default mapping",
+  })), [items]);
+  const columnDefs = useMemo(() => [
+    { field: "name", flex: 1.1, headerName: "Name", minWidth: 180 },
+    { field: "bank_name", flex: 1, headerName: "Bank", minWidth: 160 },
+    { field: "currency", headerName: "Currency", minWidth: 115, width: 120 },
+    { field: "owners", headerName: "Owners", minWidth: 105, width: 110 },
+    { field: "account_number", flex: 1, headerName: "Account Number", minWidth: 180 },
+    { field: "default_mapping_text", flex: 1.2, headerName: "Default Mapping", minWidth: 210, tooltipField: "default_mapping_text" },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="bank-account-definition-grid" columnDefs={columnDefs} items={items} rowData={rowData} />;
+}
+
+function CategoryDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const columnDefs = useMemo(() => [
+    { cellRenderer: DefinitionGridColorCell, field: "color", filter: false, headerName: "Color", minWidth: 120, width: 125 },
+    { field: "name", flex: 1, headerName: "Name", minWidth: 200 },
+    { field: "description", flex: 1.6, headerName: "Description", minWidth: 260, tooltipField: "description" },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="category-definition-grid" columnDefs={columnDefs} items={items} rowData={items} />;
+}
+
+function SubcategoryDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const rowData = useMemo(() => items.map((item) => ({
+    ...item,
+    category_text: item.category?.name || "No category",
+  })), [items]);
+  const columnDefs = useMemo(() => [
+    { cellRenderer: DefinitionGridColorCell, field: "color", filter: false, headerName: "Color", minWidth: 120, width: 125 },
+    { field: "name", flex: 1, headerName: "Name", minWidth: 190 },
+    { field: "category_text", flex: 1, headerName: "Category", minWidth: 190 },
+    { field: "description", flex: 1.4, headerName: "Description", minWidth: 240, tooltipField: "description" },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="subcategory-definition-grid" columnDefs={columnDefs} items={items} rowData={rowData} />;
+}
+
+function TagDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const columnDefs = useMemo(() => [
+    { cellRenderer: DefinitionGridColorCell, field: "color", filter: false, headerName: "Color", minWidth: 120, width: 125 },
+    { field: "name", flex: 1, headerName: "Name", minWidth: 200 },
+    { field: "description", flex: 1.6, headerName: "Description", minWidth: 260, tooltipField: "description" },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="tag-definition-grid" columnDefs={columnDefs} items={items} rowData={items} />;
+}
+
+function KeywordDefinitionGrid({ confirmAction, endpoint, items, notify, onDeleted, onEdit, reloadAll }) {
+  const rowData = useMemo(() => items.map((item) => ({
+    ...item,
+    include_terms_text: (item.include_terms || []).join(", "),
+    exclude_terms_text: (item.exclude_terms || []).join(", "),
+    subcategory_text: item.subcategory?.name || "No subcategory",
+    tags_text: (item.tags || []).map((tag) => tag.name).join(", "),
+    wni_text: item.want_need_investment ? titleCase(item.want_need_investment) : "No WNI",
+  })), [items]);
+  const columnDefs = useMemo(() => [
+    {
+      field: "name",
+      flex: 1.2,
+      headerName: "Name",
+      minWidth: 180,
+    },
+    {
+      field: "include_terms_text",
+      flex: 1.6,
+      headerName: "Include",
+      minWidth: 220,
+      tooltipField: "include_terms_text",
+    },
+    {
+      field: "exclude_terms_text",
+      flex: 1,
+      headerName: "Exclude",
+      minWidth: 160,
+      tooltipField: "exclude_terms_text",
+    },
+    {
+      field: "subcategory_text",
+      headerName: "Subcategory",
+      minWidth: 160,
+      width: 180,
+    },
+    {
+      field: "wni_text",
+      headerName: "WNI",
+      minWidth: 120,
+      width: 130,
+    },
+    {
+      field: "tags_text",
+      flex: 1,
+      headerName: "Tags",
+      minWidth: 160,
+      tooltipField: "tags_text",
+    },
+    {
+      field: "priority",
+      headerName: "Priority",
+      minWidth: 110,
+      width: 110,
+    },
+    {
+      field: "is_ignored",
+      headerName: "Ignored",
+      minWidth: 110,
+      valueFormatter: (params) => (params.value ? "Yes" : "No"),
+      width: 110,
+    },
+    definitionActionColumn({ confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll }),
+  ], [confirmAction, endpoint, notify, onDeleted, onEdit, reloadAll]);
+
+  return <DefinitionAgGridList className="keyword-definition-grid" columnDefs={columnDefs} items={items} rowData={rowData} />;
 }
 
 function HelpTooltip({ text }) {

--- a/frontend/src/pages/DefinitionsPage.jsx
+++ b/frontend/src/pages/DefinitionsPage.jsx
@@ -50,13 +50,13 @@ export default function DefinitionsPage({ confirmAction, mappingDraft, notify, r
 
   return (
     <div className="definitions-grid">
-      <CollapsiblePanel defaultExpanded storageId="app-settings" subtitle="Currency, exchange rates, and transfer automation" title="App Settings" wide>
+      <CollapsiblePanel storageId="app-settings" subtitle="Currency, exchange rates, and transfer automation" title="App Settings" wide>
         <SettingsForm notify={notify} refs={refs} reloadAll={reloadAll} reloadDashboard={reloadDashboard} settings={refs.settings} />
       </CollapsiblePanel>
-      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/csv-mappings/" formatter={(item) => [item.name, `${item.delimiter} - ${item.date_format}`]} helpText={definitionHelp["CSV Mappings"]} items={refs.mappings} notify={notify} onDeleted={() => clearEditing("/csv-mappings/")} onEdit={(item) => editItem("/csv-mappings/", item)} reloadAll={reloadAll} subtitle="CSV import parsers" title="CSV Mappings" wide>
         <MappingForm clearEditing={() => clearEditing("/csv-mappings/")} draft={mappingDraft} editingItem={editingItems["/csv-mappings/"]} notify={notify} refs={refs} reloadAll={reloadAll} setDraft={setMappingDraft} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/bank-accounts/" formatter={(item) => [item.name, bankAccountSubtitle(item)]} helpText={definitionHelp["Bank Accounts"]} items={refs.accounts} notify={notify} onDeleted={() => clearEditing("/bank-accounts/")} onEdit={(item) => editItem("/bank-accounts/", item)} reloadAll={reloadAll} subtitle="Accounts available for imports" title="Bank Accounts">
         <AccountForm clearEditing={() => clearEditing("/bank-accounts/")} editingItem={editingItems["/bank-accounts/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
       <DefinitionPanel confirmAction={confirmAction} endpoint="/categories/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Categories} items={refs.categories} notify={notify} onDeleted={() => clearEditing("/categories/")} onEdit={(item) => editItem("/categories/", item)} reloadAll={reloadAll} subtitle="Top-level reporting buckets" title="Categories">
@@ -68,7 +68,7 @@ export default function DefinitionsPage({ confirmAction, mappingDraft, notify, r
       <DefinitionPanel confirmAction={confirmAction} endpoint="/tags/" formatter={(item) => [item.name, item.description || ""]} helpText={definitionHelp.Tags} items={refs.tags} notify={notify} onDeleted={() => clearEditing("/tags/")} onEdit={(item) => editItem("/tags/", item)} reloadAll={reloadAll} subtitle="Flexible transaction labels" title="Tags">
         <SimpleForm clearEditing={() => clearEditing("/tags/")} editingItem={editingItems["/tags/"]} endpoint="/tags/" entityLabel="Tag" fields={[["name", "Name", true], ["color", "Color"], ["description", "Description"]]} items={refs.tags} notify={notify} reloadAll={reloadAll} />
       </DefinitionPanel>
-      <DefinitionPanel confirmAction={confirmAction} defaultExpanded endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
+      <DefinitionPanel confirmAction={confirmAction} endpoint="/keywords/" formatter={(item) => [item.name, `${(item.include_terms || []).join(", ")} - ${item.subcategory?.name || "No subcategory"} - ${item.want_need_investment || "No WNI"}`]} helpText={definitionHelp.Keywords} items={refs.keywords} notify={notify} onDeleted={() => clearEditing("/keywords/")} onEdit={(item) => editItem("/keywords/", item)} reloadAll={reloadAll} subtitle="Categorization rules" title="Keywords" wide>
         <KeywordForm clearEditing={() => clearEditing("/keywords/")} editingItem={editingItems["/keywords/"]} notify={notify} refs={refs} reloadAll={reloadAll} />
       </DefinitionPanel>
     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2437,6 +2437,14 @@ select option {
   border-bottom: 0;
 }
 
+.raw-data-row.is-categorization-field {
+  border-color: color-mix(in srgb, var(--action) 38%, var(--border));
+  background: color-mix(in srgb, var(--action) 10%, transparent);
+  border-radius: 6px;
+  margin: 2px 0;
+  padding-inline: 7px;
+}
+
 .raw-data-key,
 .raw-data-value {
   margin: 0;
@@ -2446,9 +2454,22 @@ select option {
 
 .raw-data-key {
   color: var(--muted);
+  display: grid;
+  gap: 4px;
   font-size: 12px;
   font-weight: 760;
   line-height: 1.35;
+}
+
+.raw-data-badge {
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--action) 50%, var(--border));
+  border-radius: 999px;
+  color: var(--action);
+  font-size: 10px;
+  font-weight: 820;
+  line-height: 1;
+  padding: 3px 6px;
 }
 
 .raw-data-value {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3474,8 +3474,6 @@ td {
   max-height: min(52vh, 520px);
   overflow-y: auto;
   overflow-x: hidden;
-  padding-right: 2px;
-  scrollbar-gutter: stable;
 }
 
 .maintenance-backup-row {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3311,6 +3311,81 @@ td {
   overflow: auto;
 }
 
+.definition-grid-list {
+  width: 100%;
+  min-height: 190px;
+  margin-top: 14px;
+}
+
+.definition-grid-list .ag-cell {
+  border-right: 1px solid var(--border);
+}
+
+.definition-grid-list .ag-cell:last-child {
+  border-right: 0;
+}
+
+.definition-grid-list .ag-header-cell {
+  border-right: 1px solid var(--border);
+}
+
+.definition-grid-list .ag-header-cell:last-child {
+  border-right: 0;
+}
+
+.definition-grid-list .ag-cell-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.definition-grid-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  width: 100%;
+}
+
+.definition-grid-list .definition-grid-actions-cell {
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.definition-grid-actions .edit-button,
+.definition-grid-actions .delete-button {
+  min-height: 28px;
+  padding-block: 4px;
+}
+
+.definition-grid-color {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+}
+
+.definition-grid-color-swatch {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.definition-grid-color-empty {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.definition-grid-empty {
+  margin-top: 14px;
+}
+
 .item-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- Add exchange-rate backed currency conversion support for transactions and reporting.
- Show import duplicate details in the frontend and allow bank accounts without required account numbers.
- Rework Definitions forms into modal flows with collapsible sections and AG Grid list tables.
- Add an uncategorized transaction review modal based on categorization-field grouping.
- Add dashboard raw transaction data popovers, including highlighted categorization fields.
- Reorganize Maintenance with saved backup management, restore/export/delete actions, and cleaner section layout.
- Polish Electron packaging/icon behavior, inactive button cursors, filters UI, and confirmation dialogs.

## Testing

- `.\build_frontend.bat --skip-setup`